### PR TITLE
Dutch

### DIFF
--- a/languages/nl_NL.json
+++ b/languages/nl_NL.json
@@ -1,0 +1,9 @@
+{
+	"plugin-data":
+	{
+		"name": "Tekstvak",
+		"description": "Toont tekst in de zijbalk inclusief HTML-opmaak."
+	},
+	"plugin-label": "Label voor tekstvak",
+	"text": "Tekst of HTML-code"
+}


### PR DESCRIPTION
"plugin-label" and "text" are missing from the other languages.